### PR TITLE
Add download link for Arch Linux

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,7 +162,8 @@ with DVI at all, but can generally treat TeX as a system that goes directly from
     <a href="https://launchpad.net/~texworks/+archive/stable">Ubuntu</a>,
     <a href="http://software.opensuse.org/package/texworks">openSUSE</a>,
     <a href="http://packages.debian.org/de/sid/texworks">Debian</a>,
-    <a href="https://admin.fedoraproject.org/pkgdb/package/texworks/">Fedora</a>
+    <a href="https://admin.fedoraproject.org/pkgdb/package/texworks/">Fedora</a>,
+    <a href="https://aur.archlinux.org/packages/texworks/">Arch Linux</a>
   </li>
 </ul>
 <p>

--- a/index.html
+++ b/index.html
@@ -155,9 +155,9 @@ with DVI at all, but can generally treat TeX as a system that goes directly from
 
 <p>You can get stable release binaries for the following platforms:</p>
 <ul>
-	<li>Microsoft Windows: <a href="https://github.com/TeXworks/texworks/releases">TeXworks</a> installer</li>
-	<li>Mac OS X: <a href="https://github.com/TeXworks/texworks/releases">TeXworks</a> disk images</li>
-	<li>
+  <li>Microsoft Windows: <a href="https://github.com/TeXworks/texworks/releases">TeXworks</a> installer</li>
+  <li>Mac OS X: <a href="https://github.com/TeXworks/texworks/releases">TeXworks</a> disk images</li>
+  <li>
     GNU/Linux:
     <a href="https://launchpad.net/~texworks/+archive/stable">Ubuntu</a>,
     <a href="http://software.opensuse.org/package/texworks">openSUSE</a>,

--- a/index.html
+++ b/index.html
@@ -157,7 +157,13 @@ with DVI at all, but can generally treat TeX as a system that goes directly from
 <ul>
 	<li>Microsoft Windows: <a href="https://github.com/TeXworks/texworks/releases">TeXworks</a> installer</li>
 	<li>Mac OS X: <a href="https://github.com/TeXworks/texworks/releases">TeXworks</a> disk images</li>
-	<li>GNU/Linux: <a href="https://launchpad.net/~texworks/+archive/stable">Ubuntu</a>, <a href="http://software.opensuse.org/package/texworks">openSUSE</a>, <a href="http://packages.debian.org/de/sid/texworks">Debian</a>, <a href="https://admin.fedoraproject.org/pkgdb/package/texworks/">Fedora</a></li>
+	<li>
+    GNU/Linux:
+    <a href="https://launchpad.net/~texworks/+archive/stable">Ubuntu</a>,
+    <a href="http://software.opensuse.org/package/texworks">openSUSE</a>,
+    <a href="http://packages.debian.org/de/sid/texworks">Debian</a>,
+    <a href="https://admin.fedoraproject.org/pkgdb/package/texworks/">Fedora</a>
+  </li>
 </ul>
 <p>
   For the latest development versions, see <a href="#Online_resources">Online resources</a>.


### PR DESCRIPTION
Title says it all. The link points to the Arch User Repository (AUR), where TeXworks is packaged for this distribution.