### PR TITLE
Updated link to current TeXShop website

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@ td {
 
 <h3 id="Introduction">Introduction</h3>
 
-<p>The TeXworks project is an effort to build a simple TeX front-end program (working environment) that will be available for all today's major desktop operating systems—in particular, MS Windows (7/8/8.1/10), typical GNU/Linux distros and other X11-based systems, as well as Mac&nbsp;OS&nbsp;X. It is deliberately modeled on Dick Koch's award-winning <a href="http://www.uoregon.edu/~koch/texshop/">TeXShop</a> for Mac&nbsp;OS&nbsp;X, which is <a href="http://en.wikipedia.org/wiki/TeXShop">credited</a> with a resurgence of TeX usage on the Mac platform.</p>
+<p>The TeXworks project is an effort to build a simple TeX front-end program (working environment) that will be available for all today's major desktop operating systems—in particular, MS Windows (7/8/8.1/10), typical GNU/Linux distros and other X11-based systems, as well as Mac&nbsp;OS&nbsp;X. It is deliberately modeled on Dick Koch's award-winning <a href="https://pages.uoregon.edu/koch/texshop/">TeXShop</a> for Mac&nbsp;OS&nbsp;X, which is <a href="http://en.wikipedia.org/wiki/TeXShop">credited</a> with a resurgence of TeX usage on the Mac platform.</p>
 
 <p>To provide a similar experience across all systems, TeXworks is based on cross-platform, open source tools and libraries. The <a href="http://qt-project.org/">Qt toolkit</a> was chosen for the quality of its cross-platform user interface capabilities, with native “look and feel” on each platform being a realistic target. Qt also provides a rich application framework, facilitating the relatively rapid development of a usable product.</p>
 


### PR DESCRIPTION
https://pages.uoregon.edu/koch/texshop/ is the current website, replaced 404 link currently in index.html